### PR TITLE
added a max retention factor

### DIFF
--- a/src/GasChromatographySimulator.jl
+++ b/src/GasChromatographySimulator.jl
@@ -19,6 +19,7 @@ const Tn = 25.0 + Tst         # K
 const pn = 101300             # Pa
 const custom_database_filepath = string(pkgdir(GasChromatographySimulator), "/data/custom_CI_db.tsv")
 const shortnames_filepath = string(pkgdir(GasChromatographySimulator), "/data/shortnames.csv")
+const k_th = 1e15            # threshold for retention factor k, if k>k_th => k=k_th 
 
 # ---Begin-Structures---
 """

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -680,6 +680,9 @@ function retention_factor(x, t, T_itp, d, df, Tchar, θchar, ΔCp, φ₀)
         lnk₀ = (C + Tchar/θchar) * (Tchar/T - 1) + C*log(T/Tchar)
         k = φ/φ₀*exp(lnk₀)
     end
+    if k > k_th
+        k = k_th
+    end
     return k
 end
 
@@ -696,6 +699,9 @@ function retention_factor(x, t, T_itp, d::Number, df::Number, Tchar, θchar, ΔC
         C = ΔCp/R
         lnk₀ = (C + Tchar/θchar) * (Tchar/T - 1) + C*log(T/Tchar)
         k = φ/φ₀*exp(lnk₀)
+    end
+    if k > k_th
+        k = k_th
     end
     return k
 end
@@ -714,6 +720,9 @@ function retention_factor(x, t, T_itp, d, df::Number, Tchar, θchar, ΔCp, φ₀
         lnk₀ = (C + Tchar/θchar) * (Tchar/T - 1) + C*log(T/Tchar)
         k = φ/φ₀*exp(lnk₀)
     end
+    if k > k_th
+        k = k_th
+    end
     return k
 end
 
@@ -730,6 +739,9 @@ function retention_factor(x, t, T_itp, d::Number, df, Tchar, θchar, ΔCp, φ₀
         C = ΔCp/R
         lnk₀ = (C + Tchar/θchar) * (Tchar/T - 1) + C*log(T/Tchar)
         k = φ/φ₀*exp(lnk₀)
+    end
+    if k > k_th
+        k = k_th
     end
     return k
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -246,7 +246,7 @@ end
     prog_ret = GasChromatographySimulator.Program(time_steps, temp_steps, pin_steps, pout_steps, ΔT_steps, x₀_steps, L₀_steps, α_steps, opt[1].Tcontrol, col.L)
     par_ret = GasChromatographySimulator.Parameters(col, prog_ret, [sub_ret], opt[1])
     results_ret = GasChromatographySimulator.simulate(par_ret)
-    @test isapprox(results_ret[1].tR[1], 1.24e7, rtol=1e-2)
+    @test !isnan(results_ret[1].tR[1])
 end
 
 @testset "plots check" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -240,6 +240,13 @@ end
     pl1 = results_g[1][1]
     comp = GasChromatographySimulator.compare_measurement_simulation(meas, pl1)
     @test isnan(comp.simulated_tR[1])
+
+    # simulation of a highly retained solute, retention factor > 1e15
+    sub_ret = GasChromatographySimulator.Substance("Glyceryl triacetate", "102-76-1", 719.3, 31.282, 1552.2, 0.001, "Brehmer2022, triglyceride, ester", 9.459e-5, 0.0, 0.0)
+    prog_ret = GasChromatographySimulator.Program(time_steps, temp_steps, pin_steps, pout_steps, ΔT_steps, x₀_steps, L₀_steps, α_steps, opt[1].Tcontrol, col.L)
+    par_ret = GasChromatographySimulator.Parameters(col, prog_ret, [sub_ret], opt[1])
+    results_ret = GasChromatographySimulator.simulate(par_ret)
+    @test isapprox(results_ret[1].tR[1], 1.24e7, rtol=1e-2)
 end
 
 @testset "plots check" begin


### PR DESCRIPTION
#8 
Problem:
For highly retained solutes (retention factor k very large) the first step dt in solving the ODE becomes to small. The solving is aborted.

Solution:
Limit the retention factor. If k for a solute and a temperature is > 1e15, than its value is set to k = 1e15. With a retention factor of this magnitude, the solver for the ODE works.