### PR TITLE
For retention parameter estimator

### DIFF
--- a/src/GasChromatographySimulator.jl
+++ b/src/GasChromatographySimulator.jl
@@ -1110,7 +1110,7 @@ Note: The result is the solution structure from
 DifferentialEquations.jl.    
 """
 function solving_migration(Tchar, θchar, ΔCp, φ₀, L, d, df, prog, opt, gas)
-	t_tz(t,p,z) = residency(z, t, prog.T_itp, prog.Fpin_itp, prog.pout_itp, p[5], p[6], p[7], gas, p[1], p[2], p[3], p[4]; ng=opt.ng, vis=opt.vis, control=opt.control)
+	f_tz(t,p,z) = residency(z, t, prog.T_itp, prog.Fpin_itp, prog.pout_itp, p[5], p[6], p[7], gas, p[1], p[2], p[3], p[4]; ng=opt.ng, vis=opt.vis, control=opt.control)
 	t₀ = 0.0
 	zspan = (0.0, L)
 	p = [Tchar, θchar, ΔCp, φ₀, L, d, df]

--- a/src/GasChromatographySimulator.jl
+++ b/src/GasChromatographySimulator.jl
@@ -1100,6 +1100,27 @@ function solving_migration(col::Column, prog::Program, sub::Substance, opt::Opti
 end
 
 """
+    solving_migration(Tchar, θchar, ΔCp, φ₀, L, d, df, prog, opt, gas)
+
+Solve for the migration ``t(z)`` of solute with retention parameters `Tchar` `θchar` and `ΔCp` estimated for a dimensionless
+film thickness `φ₀` in a GC Column with length `L`, internal diameter `d` and film thickness `df` for a GC program `prog`, 
+options `opt` and mobile phase `gas`.
+    
+Note: The result is the solution structure from
+DifferentialEquations.jl.    
+"""
+function solving_migration(Tchar, θchar, ΔCp, φ₀, L, d, df, prog, opt, gas)
+	t_tz(t,p,z) = residency(z, t, prog.T_itp, prog.Fpin_itp, prog.pout_itp, p[5], p[6], p[7], gas, p[1], p[2], p[3], p[4]; ng=opt.ng, vis=opt.vis, control=opt.control)
+	t₀ = 0.0
+	zspan = (0.0, L)
+	p = [Tchar, θchar, ΔCp, φ₀, L, d, df]
+	prob_tz = ODEProblem(f_tz, t₀, zspan, p)
+	solution_tz = solve(prob_tz, alg=opt.alg, abstol=opt.abstol, reltol=opt.reltol)
+	#tR = solution.u[end]
+	return solution_tz
+end
+
+"""
     solving_peakvariance(solution_tz, col::Column, prog::Program, sub::Substance, opt::Options)
 
 Solve for the development of the peak variance ``τ²(z)`` of solute `sub` in the GC Column `col` with

--- a/src/GasChromatographySimulator.jl
+++ b/src/GasChromatographySimulator.jl
@@ -685,7 +685,11 @@ function CAS_identification(Name::Array{String})
 		else
 			ci = search_chemical(Name[i])
 		end
-		CAS[i] = string(ci.CAS[1], "-", ci.CAS[2], "-", ci.CAS[3])
+        if length(digits(ci.CAS[2])) == 1
+            CAS[i] = string(ci.CAS[1], "-0", ci.CAS[2], "-", ci.CAS[3])
+        else
+		    CAS[i] = string(ci.CAS[1], "-", ci.CAS[2], "-", ci.CAS[3])
+        end
 	end
 	id = DataFrame(Name=Name, CAS=CAS)
 	return id

--- a/src/GasChromatographySimulator.jl
+++ b/src/GasChromatographySimulator.jl
@@ -1211,7 +1211,7 @@ See also: [`solving_odesystem_r`](@ref), [`odesystem_r!`](@ref)
 """
 function peakode(z, t, τ², col, prog, sub, opt)
     if opt.ng==true
-        r_ng(zt) = residency(zt[1], zt[2], prog.T_itp, prog.Fpin_itp, prog.pout_itp, col.L, col.d, col.df, col.gas, sub.Tchar, sub.θchar, sub.ΔCp, sub.φ₀; ng=true, vis=opt.vis, control=opt.control, k_th=opt.kth)
+        r_ng(zt) = residency(zt[1], zt[2], prog.T_itp, prog.Fpin_itp, prog.pout_itp, col.L, col.d, col.df, col.gas, sub.Tchar, sub.θchar, sub.ΔCp, sub.φ₀; ng=true, vis=opt.vis, control=opt.control, k_th=opt.k_th)
         H_ng(z,t) = plate_height(z, t, prog.T_itp, prog.Fpin_itp, prog.pout_itp, col.L, col.d, col.df, col.gas, sub.Tchar, sub.θchar, sub.ΔCp, sub.φ₀, sub.Cag; ng=true, vis=opt.vis, control=opt.control, k_th=opt.k_th)
         ∂r∂t_ng(z,t) = ForwardDiff.gradient(r_ng, [z, t])[2]
         return H_ng(z,t)*r_ng([z,t])^2 + 2*τ²*∂r∂t_ng(z,t)

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -36,24 +36,24 @@ function pressure(x, t, T_itp, Fpin_itp, pout_itp, L, d, gas; ng=false, vis="Blu
     if ng==true
         if control == "Pressure"
             pin_itp = Fpin_itp
-            pp = sqrt(pin_itp(t)^2 - x/L*(pin_itp(t)^2-pout_itp(t)^2))
+            pp = real(sqrt(Complex(pin_itp(t)^2 - x/L*(pin_itp(t)^2-pout_itp(t)^2))))
         elseif control == "Flow"
             F_itp = Fpin_itp
             if isa(d, Function) 
-                pp = sqrt(pout_itp(t)^2 + 256/π * pn/Tn * viscosity(x, t, T_itp, gas, vis=vis)* T_itp(x,t)/d(x)^4 * F_itp(t) * (L - x))
+                pp = real(sqrt(Complex(pout_itp(t)^2 + 256/π * pn/Tn * viscosity(x, t, T_itp, gas, vis=vis)* T_itp(x,t)/d(x)^4 * F_itp(t) * (L - x))))
             else
-                pp = sqrt(pout_itp(t)^2 + 256/π * pn/Tn * viscosity(x, t, T_itp, gas, vis=vis)* T_itp(x,t)/d^4 * F_itp(t) * (L - x))
+                pp = real(sqrt(Complex(pout_itp(t)^2 + 256/π * pn/Tn * viscosity(x, t, T_itp, gas, vis=vis)* T_itp(x,t)/d^4 * F_itp(t) * (L - x))))
             end
         end
     else
         if control == "Pressure"
             pin_itp = Fpin_itp
-            pp = sqrt(pin_itp(t)^2 - flow_restriction(x, t, T_itp, d, gas, vis=vis)/flow_restriction(L, t, T_itp, d, gas, vis=vis)*(pin_itp(t)^2-pout_itp(t)^2))
+            pp = real(sqrt(Complex(pin_itp(t)^2 - flow_restriction(x, t, T_itp, d, gas, vis=vis)/flow_restriction(L, t, T_itp, d, gas, vis=vis)*(pin_itp(t)^2-pout_itp(t)^2))))
         elseif control == "Flow"
             F_itp = Fpin_itp
             κL = flow_restriction(L, t, T_itp, d, gas, vis=vis)
             κx = flow_restriction(x, t, T_itp, d, gas, vis=vis)
-            pp = sqrt(pout_itp(t)^2 + 256/π * pn/Tn * F_itp(t) * (κL - κx))
+            pp = real(sqrt(Complex(pout_itp(t)^2 + 256/π * pn/Tn * F_itp(t) * (κL - κx))))
         end
     end
     return pp
@@ -273,10 +273,10 @@ function inlet_pressure(t, T_itp, Fpin_itp, pout_itp, L, d, gas; ng=false, vis="
     elseif control == "Flow"
         F_itp = Fpin_itp
         if ng == true 
-            pin = sqrt(pout_itp(t)^2 + 256/π * pn/Tn * viscosity(0.0, t, T_itp, gas; vis="Blumberg") * T_itp(0.0, t) * L / d(0.0)^4 * F_itp(t))
+            pin = real(sqrt(Complex(pout_itp(t)^2 + 256/π * pn/Tn * viscosity(0.0, t, T_itp, gas; vis="Blumberg") * T_itp(0.0, t) * L / d(0.0)^4 * F_itp(t))))
         else
             κL = flow_restriction(L, t, T_itp, d, gas, vis=vis)
-            pin = sqrt(pout_itp(t)^2 + 256/π * pn/Tn * κL * F_itp(t))
+            pin = real(sqrt(Complex(pout_itp(t)^2 + 256/π * pn/Tn * κL * F_itp(t))))
         end
     end
     return pin
@@ -288,10 +288,10 @@ function inlet_pressure(t, T_itp, Fpin_itp, pout_itp, L, d::Number, gas; ng=fals
     elseif control == "Flow"
         F_itp = Fpin_itp
         if ng == true 
-            pin = sqrt(pout_itp(t)^2 + 256/π * pn/Tn * viscosity(0.0, t, T_itp, gas; vis="Blumberg") * T_itp(0.0, t) * L / d^4 * F_itp(t))
+            pin = real(sqrt(Complex(pout_itp(t)^2 + 256/π * pn/Tn * viscosity(0.0, t, T_itp, gas; vis="Blumberg") * T_itp(0.0, t) * L / d^4 * F_itp(t))))
         else
             κL = flow_restriction(L, t, T_itp, d, gas, vis=vis)
-            pin = sqrt(pout_itp(t)^2 + 256/π * pn/Tn * κL * F_itp(t))
+            pin = real(sqrt(Complex(pout_itp(t)^2 + 256/π * pn/Tn * κL * F_itp(t))))
         end
     end
     return pin
@@ -326,7 +326,7 @@ function holdup_time(T::Float64, Fpin::Float64, pout::Float64, L::Float64, d::Fl
         pin = Fpin
     elseif control == "Flow"
         F = Fpin
-        pin = sqrt(pout^2 + 256/π * pn/Tn * viscosity(T, gas; vis="Blumberg") * T * L / d^4 * F)
+        pin = real(sqrt(Complex(pout^2 + 256/π * pn/Tn * viscosity(T, gas; vis="Blumberg") * T * L / d^4 * F)))
     end
 	tM = 128/3*L^2/d^2*η*(pin^3-pout^3)/(pin^2-pout^2)^2
 	return tM

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -805,7 +805,7 @@ See also: [`diffusion_mobile`](@ref), [`mobile_phase_residency`](@ref), [`retent
 function plate_height(x, t, T_itp, Fpin_itp, pout_itp, L, d, df, gas, Tchar, θchar, ΔCp, φ₀, Cag; ng=false, vis="Blumberg", control="Pressure", k_th=1e12)
     id = d(x)# - 2.0*df(x)
     uM = 1/mobile_phase_residency(x, t, T_itp, Fpin_itp, pout_itp, L, d, gas; ng=ng, vis=vis, control=control)
-    μ = 1/(1 + retention_factor(x, t, T_itp, d, df, Tchar, θchar, ΔCp, φ₀, k_th))
+    μ = 1/(1 + retention_factor(x, t, T_itp, d, df, Tchar, θchar, ΔCp, φ₀, k_th=k_th))
     DM = diffusion_mobile(x, t, T_itp, Fpin_itp, pout_itp, L, d, gas, Cag; ng=ng, vis=vis, control=control)
     DS = DM/10000
     H1 = 2*DM/uM
@@ -818,7 +818,7 @@ end
 function plate_height(x, t, T_itp, Fpin_itp, pout_itp, L, d::Number, df::Number, gas, Tchar, θchar, ΔCp, φ₀, Cag; ng=false, vis="Blumberg", control="Pressure", k_th=1e12)
     id = d# - 2.0*df
     uM = 1/mobile_phase_residency(x, t, T_itp, Fpin_itp, pout_itp, L, d, gas; ng=ng, vis=vis, control=control)
-    μ = 1/(1 + retention_factor(x, t, T_itp, d, df, Tchar, θchar, ΔCp, φ₀, k_th))
+    μ = 1/(1 + retention_factor(x, t, T_itp, d, df, Tchar, θchar, ΔCp, φ₀, k_th=k_th))
     DM = diffusion_mobile(x, t, T_itp, Fpin_itp, pout_itp, L, d, gas, Cag; ng=ng, vis=vis, control=control)
     DS = DM/10000
     H1 = 2*DM/uM
@@ -831,7 +831,7 @@ end
 function plate_height(x, t, T_itp, Fpin_itp, pout_itp, L, d, df::Number, gas, Tchar, θchar, ΔCp, φ₀, Cag; ng=false, vis="Blumberg", control="Pressure", k_th=1e12)
     id = d(x)# - 2.0*df
     uM = 1/mobile_phase_residency(x, t, T_itp, Fpin_itp, pout_itp, L, d, gas; ng=ng, vis=vis, control=control)
-    μ = 1/(1 + retention_factor(x, t, T_itp, d, df, Tchar, θchar, ΔCp, φ₀, k_th))
+    μ = 1/(1 + retention_factor(x, t, T_itp, d, df, Tchar, θchar, ΔCp, φ₀, k_th=k_th))
     DM = diffusion_mobile(x, t, T_itp, Fpin_itp, pout_itp, L, d, gas, Cag; ng=ng, vis=vis, control=control)
     DS = DM/10000
     H1 = 2*DM/uM
@@ -844,7 +844,7 @@ end
 function plate_height(x, t, T_itp, Fpin_itp, pout_itp, L, d::Number, df, gas, Tchar, θchar, ΔCp, φ₀, Cag; ng=false, vis="Blumberg", control="Pressure", k_th=1e12)
     id = d# - 2.0*df(x)
     uM = 1/mobile_phase_residency(x, t, T_itp, Fpin_itp, pout_itp, L, d, gas; ng=ng, vis=vis, control=control)
-    μ = 1/(1 + retention_factor(x, t, T_itp, d, df, Tchar, θchar, ΔCp, φ₀, k_th))
+    μ = 1/(1 + retention_factor(x, t, T_itp, d, df, Tchar, θchar, ΔCp, φ₀, k_th=k_th))
     DM = diffusion_mobile(x, t, T_itp, Fpin_itp, pout_itp, L, d, gas, Cag; ng=ng, vis=vis, control=control)
     DS = DM/10000
     H1 = 2*DM/uM


### PR DESCRIPTION
- added some functions for usage in the `RetentionDataEstimator.jl` package
- changed `sqrt` in local pressure functions to avoid `DomainError` by using `real(sqrt(x))`
- added the parameter `k_th` (a maxima threshold for the retention factor) to the `Options` structure
- corrected the reading of the CAS number from `ChemicalIdentifiers.jl` to have always two digits in the second part (add a leading 0, if `ChemicalIdentifiers.jl` has only one digit for the second part) 