### PR TITLE
patch for CAS is missing

### DIFF
--- a/src/GasChromatographySimulator.jl
+++ b/src/GasChromatographySimulator.jl
@@ -692,9 +692,17 @@ function CAS_identification(Name::Array{<:AbstractString})
 	for i=1:length(Name)
 		if Name[i] in shortnames.shortname
 			j = findfirst(Name[i].==shortnames.shortname)
-			ci = search_chemical(String(shortnames.name[j]))
+			ci = try
+                search_chemical(String(shortnames.name[j]))
+            catch
+                missing
+            end
 		else
-			ci = search_chemical(String(Name[i]))
+			ci = try
+                search_chemical(String(Name[i]))
+            catch
+                missing
+            end
 		end
         if ismissing(ci)
             if Name[i] in missingsubs.name

--- a/src/GasChromatographySimulator.jl
+++ b/src/GasChromatographySimulator.jl
@@ -104,7 +104,7 @@ See also: [`load_solute_database`](@ref)
 """
 struct Substance
     name::String        # name of solute
-    CAS::String         # CAS registry number
+    CAS::Union{Missing,String}         # CAS registry number
     Tchar               # characteristic temperature in K
     θchar               # characteristic thermal constant in °C
     ΔCp                 # 3rd parameter

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -937,7 +937,8 @@ end
     diffusivity(CAS, gas)
 
 Calculate the diffusivity constant `Cag` of solute `a` in gas `g` using the
-emperical Fuller-Schettler-Giddings model [1], using the CAS number to look the formula of the solute up in ChemicalIdentifiers.jl.
+emperical Fuller-Schettler-Giddings model [1], using the CAS number to look the formula of the solute up in ChemicalIdentifiers.jl. 
+`CAS` can also be the PubChem ID. If `CAS` is neither a CAS number nor a PubChem ID, the diffusitivity of n-Pentadecane is used as a placeholder.   
 
 [1] Fuller, Edward N.; Ensley, Keith; Giddings, J. Calvin, Diffusion of
 Halogenated Hydrocarbons in Helium. The Effect of Structure on Collision
@@ -969,8 +970,10 @@ function diffusivity(CAS, gas)
     regexCAS = r"\b[1-9]{1}[0-9]{1,5}-\d{2}-\d\b"
     if split(CAS, ' ')[1] == "PubChem" # CAS is a pubchemid
         solute = search_chemical(split(CAS, ' ')[end])
-    else #typeof(match(regexCAS, CAS)) == RegexMatch # CAS is a CAS number
+    elseif typeof(match(regexCAS, CAS)) == RegexMatch # CAS is a CAS number
         solute = search_chemical(Tuple(parse.(Int, split(CAS, '-'))))
+    else # e.g. CAS is missing, use pentadecane as placeholder
+        solute = search_chemical("629-62-9")
     end
     formula = formula_to_dict(solute.formula)
     Rn = ring_number(solute.smiles)


### PR DESCRIPTION
- in the Substance structure CAS can be a String or Missing
- if ChemicalIdentifiers.search_chemical() produces an error, the CAS number is set to Missing  
- if CAS is not a CAS number (or PubChemID) the value of diffusitivity is set to the value of n-Pentadecane 