### PR TITLE
Add cas to peaklist

### DIFF
--- a/src/GasChromatographySimulator.jl
+++ b/src/GasChromatographySimulator.jl
@@ -1442,6 +1442,7 @@ function peaklist(sol, par)
     # sol is solution from ODE system
     No = Array{Union{Missing, Int64}}(undef, n)
     Name = Array{String}(undef, n)
+    CAS = Array{String}(undef, n)
     tR = Array{Float64}(undef, n)
     TR = Array{Float64}(undef, n)
     σR = Array{Float64}(undef, n)
@@ -1453,6 +1454,7 @@ function peaklist(sol, par)
     Annotations = Array{String}(undef, n)
     Threads.@threads for i=1:n
         Name[i] = par.sub[i].name
+        CAS[i] = par.sub[i].CAS
         if sol[i].t[end]==par.col.L
             tR[i] = sol[i].u[end][1]
             TR[i] = par.prog.T_itp(par.col.L, tR[i]) - 273.15 
@@ -1522,6 +1524,7 @@ function peaklist(sol, peak, par)
 	n = length(par.sub)
     No = Array{Union{Missing, Int64}}(undef, n)
     Name = Array{String}(undef, n)
+    CAS = Array{String}(undef, n)
     tR = Array{Float64}(undef, n)
     TR = Array{Float64}(undef, n)
     σR = Array{Float64}(undef, n)
@@ -1533,6 +1536,7 @@ function peaklist(sol, peak, par)
     Annotations = Array{String}(undef, n)
     Threads.@threads for i=1:n
         Name[i] = par.sub[i].name
+        CAS[i] = par.sub[i].CAS
         if sol[i].t[end]==par.col.L
             tR[i] = sol[i].u[end]
             TR[i] = par.prog.T_itp(par.col.L, tR[i]) - 273.15 

--- a/src/GasChromatographySimulator.jl
+++ b/src/GasChromatographySimulator.jl
@@ -1481,7 +1481,7 @@ function peaklist(sol, par)
             Annotations[i] = join(split(par.sub[i].ann, ", ")[1:end-1], ", ")
         end
     end  
-    df = sort!(DataFrame(No = No, Name = Name, tR = tR, τR = τR, TR=TR, σR = σR, uR = uR, kR = kR, ), [:tR])
+    df = sort!(DataFrame(No = No, Name = Name, CAS = CAS, tR = tR, τR = τR, TR=TR, σR = σR, uR = uR, kR = kR, ), [:tR])
     Threads.@threads for i=1:n-1
         Res[i] = (df.tR[i+1] - df.tR[i])/(2*(df.τR[i+1] + df.τR[i]))
         Δs[i] = (df.tR[i+1] - df.tR[i])/(df.τR[i+1] - df.τR[i]) * log(df.τR[i+1]/df.τR[i])
@@ -1563,7 +1563,7 @@ function peaklist(sol, peak, par)
             Annotations[i] = join(split(par.sub[i].ann, ", ")[1:end-1], ", ")
         end
     end  
-    df = sort!(DataFrame(No = No, Name = Name, tR = tR, τR = τR, TR=TR, σR = σR, uR = uR, kR = kR, ), [:tR])
+    df = sort!(DataFrame(No = No, Name = Name, CAS = CAS, tR = tR, τR = τR, TR=TR, σR = σR, uR = uR, kR = kR, ), [:tR])
     Threads.@threads for i=1:n-1
         Res[i] = (df.tR[i+1] - df.tR[i])/(2*(df.τR[i+1] + df.τR[i]))
         Δs[i] = (df.tR[i+1] - df.tR[i])/(df.τR[i+1] - df.τR[i]) * log(df.τR[i+1]/df.τR[i])

--- a/src/GasChromatographySimulator.jl
+++ b/src/GasChromatographySimulator.jl
@@ -1481,15 +1481,15 @@ function peaklist(sol, par)
             Annotations[i] = join(split(par.sub[i].ann, ", ")[1:end-1], ", ")
         end
     end  
-    df = sort!(DataFrame(No = No, Name = Name, CAS = CAS, tR = tR, τR = τR, TR=TR, σR = σR, uR = uR, kR = kR, ), [:tR])
+    df = sort!(DataFrame(No = No, Name = Name, CAS = CAS, tR = tR, τR = τR, TR=TR, σR = σR, uR = uR, kR = kR, Annotations = Annotations, ), [:tR])
     Threads.@threads for i=1:n-1
         Res[i] = (df.tR[i+1] - df.tR[i])/(2*(df.τR[i+1] + df.τR[i]))
         Δs[i] = (df.tR[i+1] - df.tR[i])/(df.τR[i+1] - df.τR[i]) * log(df.τR[i+1]/df.τR[i])
     end
     df[!, :Res] = Res
     df[!, :Δs] = Δs 
-    df[!, :Annotations] = Annotations 
-    return df
+    
+    return select(df, [:No, :Name, :CAS, :tR, :τR, :TR, :σR, :uR, :kR, :Res, :Δs, :Annotations])
 end
 
 """
@@ -1563,15 +1563,15 @@ function peaklist(sol, peak, par)
             Annotations[i] = join(split(par.sub[i].ann, ", ")[1:end-1], ", ")
         end
     end  
-    df = sort!(DataFrame(No = No, Name = Name, CAS = CAS, tR = tR, τR = τR, TR=TR, σR = σR, uR = uR, kR = kR, ), [:tR])
+    df = sort!(DataFrame(No = No, Name = Name, CAS = CAS, tR = tR, τR = τR, TR=TR, σR = σR, uR = uR, kR = kR, Annotations = Annotations, ), [:tR])
     Threads.@threads for i=1:n-1
         Res[i] = (df.tR[i+1] - df.tR[i])/(2*(df.τR[i+1] + df.τR[i]))
         Δs[i] = (df.tR[i+1] - df.tR[i])/(df.τR[i+1] - df.τR[i]) * log(df.τR[i+1]/df.τR[i])
     end
     df[!, :Res] = Res 
     df[!, :Δs] = Δs   
-    df[!, :Annotations] = Annotations 
-    return df
+    
+    return select(df, [:No, :Name, :CAS, :tR, :τR, :TR, :σR, :uR, :kR, :Res, :Δs, :Annotations])
 end
 
 """

--- a/src/GasChromatographySimulator.jl
+++ b/src/GasChromatographySimulator.jl
@@ -776,7 +776,7 @@ function load_solute_database(db_, sp, gas, solutes, t₀, τ₀)
     elseif size(db)[2]>15 && "No" ∈ names(db)
         error("Data format not supported. Use the appended database structure.")
 	elseif isa(findfirst(unique(db.Phase).==sp), Nothing) && sp!=""
-		error("Unknown selction of stationary phase. Choose one of these: $phases_db")	
+		error("Unknown selction of stationary phase. Choose one of these: $(unique(db.Phase))")	
 	else
         # 1. Filter the stationary phase
         db_filtered = filter([:Phase] => x -> x==sp, db)
@@ -1475,11 +1475,11 @@ function peaklist(sol, par)
         catch
             missing
         end
-        if ismissing(No[i])
+        #if ismissing(No[i])
             Annotations[i] = par.sub[i].ann
-        else
-            Annotations[i] = join(split(par.sub[i].ann, ", ")[1:end-1], ", ")
-        end
+        #else
+        #    Annotations[i] = join(split(par.sub[i].ann, ", ")[1:end-1], ", ")
+        #end
     end  
     df = sort!(DataFrame(No = No, Name = Name, CAS = CAS, tR = tR, τR = τR, TR=TR, σR = σR, uR = uR, kR = kR, Annotations = Annotations, ), [:tR])
     Threads.@threads for i=1:n-1


### PR DESCRIPTION
- CAS number included in peaklist
- corrected warning for selecting unknown stationary phase
- solute number stays at end of annotations