### PR TITLE
modified `compare_measurement_simulation` to accept column labels 'RT' or 'tR' for retention times

### DIFF
--- a/src/Misc.jl
+++ b/src/Misc.jl
@@ -53,8 +53,8 @@ end
 Compare the retention times of measured and simulated substances.
 
 # Arguments
-* `meas`: DataFrame consisting at least of the columns `:Name` and `:RT`
-  (measured retention time in s)
+* `meas`: DataFrame consisting at least of the columns `:Name` and `:RT` or
+  `:tR` (measured retention time in s)
 * `peaklist`: DataFrame as result from GasChromatographySimulator.jl with the
   columns `:Name` and `:tR` (simulated retention time in s).
   
@@ -65,7 +65,19 @@ and the relative difference (in %).
 function compare_measurement_simulation(meas, peaklist)
 	# check this function
 	name = meas.Name
-	tRm = meas.RT
+	name_syms = names(meas, Symbol)
+	tR_col = if :RT in name_syms
+		:RT
+	elseif :tR in name_syms
+		:tR
+	elseif "RT" in names(meas)
+		"RT"
+	elseif "tR" in names(meas)
+		"tR"
+	else
+		error("meas must have a :RT or :tR column")
+	end
+	tRm = meas[!, tR_col]
 	tRs = Array{Real}(undef, size(meas)[1])
 	for i=1:size(meas)[1]
 		i2 = findfirst(name[i].==peaklist.Name)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -283,6 +283,16 @@ end
     pl1 = results_g[1][1]
     comp = GasChromatographySimulator.compare_measurement_simulation(meas, pl1)
     @test isnan(comp.simulated_tR[1])
+    # accept :tR column
+    meas_tr = DataFrame(Name=[pl1.Name[1]], tR=[pl1.tR[1]])
+    comp_tr = GasChromatographySimulator.compare_measurement_simulation(meas_tr, pl1)
+    @test comp_tr.simulated_tR[1] == pl1.tR[1]
+    # accept String column names
+    meas_str = DataFrame("Name" => [pl1.Name[1]], "tR" => [pl1.tR[1]])
+    comp_str = GasChromatographySimulator.compare_measurement_simulation(meas_str, pl1)
+    @test comp_str.simulated_tR[1] == pl1.tR[1]
+    # error if neither RT nor tR is present
+    @test_throws ErrorException GasChromatographySimulator.compare_measurement_simulation(DataFrame(Name=["C9"]), pl1)
 
     # simulation of a highly retained solute, retention factor > 1e15
     sub_ret = GasChromatographySimulator.Substance("Glyceryl triacetate", "102-76-1", 719.3, 31.282, 1552.2, 0.001, "Brehmer2022, triglyceride, ester", 9.459e-5, 0.0, 0.0)


### PR DESCRIPTION
- modified `compare_measurement_simulation` to accept column labels 'RT' or 'tR' for retention times